### PR TITLE
docs: add English guide and Korean translation

### DIFF
--- a/README-ko.md
+++ b/README-ko.md
@@ -7,16 +7,14 @@ NAVIX는 Naver가 관리하는 Linux 배포판입니다. Naver의 인프라와 �
 
 ---
 
-## 시작하기
+## 피드백 및 지원
 
-### 소스 코드
-
-- **Source ISO:** [https://dlnavix.navercorp.com/9/x86_64/BaseOS/source/iso/](https://dlnavix.navercorp.com/9/x86_64/BaseOS/source/iso/)
-- **저장소별 소스 트리:**
-  ```
-  https://dlnavix.navercorp.com/9/x86_64/{저장소명}/source/tree/
-  ```
-  예시: `https://dlnavix.navercorp.com/9/x86_64/BaseOS/source/tree/`
+| 항목 | 링크 |
+|---|---|
+| 버그 제보 | [버그 리포트 작성하기](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=bug%2Cnew&projects=&template=bugreport.yml&title=%5BBUG%5D) [![bug](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/bug)](https://github.com/NaverCloudPlatform/Navix/labels/bug) |
+| 기능 요청 | [기능 요청하기](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=enhancement&projects=&template=feature_request.yml&title=%5BENHANCEMENT%5D) [![enhancement](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/enhancement)](https://github.com/NaverCloudPlatform/Navix/labels/enhancement) |
+| 문의하기 | [질문 등록하기](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=question&projects=&template=question.yml&title=%5BQ%5D) [![question](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/question)](https://github.com/NaverCloudPlatform/Navix/labels/question) |
+| FAQ | [docs/](https://github.com/NaverCloudPlatform/Navix/tree/main/docs) |
 
 ---
 
@@ -58,17 +56,6 @@ new → assigned → ondev → resolved → verified → closed
 ```
 
 각 상태에 대한 자세한 내용은 아래 [이슈 레이블 및 상태](#이슈-레이블-및-상태) 섹션을 참고하세요.
-
----
-
-## 피드백 및 지원
-
-| 항목 | 링크 |
-|---|---|
-| 버그 제보 | [버그 리포트 작성하기](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=bug%2Cnew&projects=&template=bugreport.yml&title=%5BBUG%5D) [![bug](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/bug)](https://github.com/NaverCloudPlatform/Navix/labels/bug) |
-| 기능 요청 | [기능 요청하기](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=enhancement&projects=&template=feature_request.yml&title=%5BENHANCEMENT%5D) [![enhancement](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/enhancement)](https://github.com/NaverCloudPlatform/Navix/labels/enhancement) |
-| 문의하기 | [질문 등록하기](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=question&projects=&template=question.yml&title=%5BQ%5D) [![question](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/question)](https://github.com/NaverCloudPlatform/Navix/labels/question) |
-| FAQ | [docs/](https://github.com/NaverCloudPlatform/Navix/tree/main/docs) |
 
 ---
 

--- a/README-ko.md
+++ b/README-ko.md
@@ -1,0 +1,87 @@
+# NAVIX (Naver Linux)
+
+NAVIX는 Naver가 관리하는 Linux 배포판입니다. Naver의 인프라와 서비스에 최적화된 안정적인 엔터프라이즈급 OS 환경을 제공합니다.
+
+- [NAVIX 홈페이지](https://navix.navercorp.com/)
+- [NAVIX 저장소](https://dlnavix.navercorp.com/)
+
+---
+
+## 시작하기
+
+### 소스 코드
+
+- **Source ISO:** [https://dlnavix.navercorp.com/9/x86_64/BaseOS/source/iso/](https://dlnavix.navercorp.com/9/x86_64/BaseOS/source/iso/)
+- **저장소별 소스 트리:**
+  ```
+  https://dlnavix.navercorp.com/9/x86_64/{저장소명}/source/tree/
+  ```
+  예시: `https://dlnavix.navercorp.com/9/x86_64/BaseOS/source/tree/`
+
+---
+
+## 기여하기
+
+버그 제보, 기능 요청, 문의 등 커뮤니티의 다양한 기여를 환영합니다.
+
+### 기여 방법
+
+#### 1. 버그 제보
+
+버그를 발견하셨다면 [버그 리포트 작성하기](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=bug%2Cnew&projects=&template=bugreport.yml&title=%5BBUG%5D)를 통해 아래 내용을 포함하여 제보해 주세요:
+
+- **컴포넌트** — 영향을 받는 패키지 또는 서브시스템 (예: `kernel`, `openssl`)
+- **버그 설명** — 문제에 대한 명확한 설명
+- **재현 방법** — 문제를 재현하는 최소한의 단계
+- **기대 동작 vs 실제 동작**
+- **환경** — OS 버전, 하드웨어 아키텍처 (예: `NAVIX 9`, `x86_64`)
+- **스크린샷 또는 로그** — 해당하는 경우
+
+#### 2. 기능 요청
+
+NAVIX 개선을 위한 아이디어가 있으신가요? [기능 요청하기](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=enhancement&projects=&template=feature_request.yml&title=%5BENHANCEMENT%5D)를 통해 아래 내용을 작성해 주세요:
+
+- 요청의 배경이 되는 문제
+- 원하는 해결 방법
+- 검토한 대안들
+
+#### 3. 문의하기
+
+NAVIX에 관한 일반적인 질문은 [질문 등록하기](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=question&projects=&template=question.yml&title=%5BQ%5D)를 이용해 주세요. 먼저 [FAQ](https://github.com/NaverCloudPlatform/Navix/tree/main/docs)에서 이미 답변된 내용인지 확인하시는 것을 권장합니다.
+
+### 이슈 처리 흐름
+
+이슈를 등록하면 아래 상태를 순서대로 거치게 됩니다:
+
+```
+new → assigned → ondev → resolved → verified → closed
+```
+
+각 상태에 대한 자세한 내용은 아래 [이슈 레이블 및 상태](#이슈-레이블-및-상태) 섹션을 참고하세요.
+
+---
+
+## 피드백 및 지원
+
+| 항목 | 링크 |
+|---|---|
+| 버그 제보 | [버그 리포트 작성하기](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=bug%2Cnew&projects=&template=bugreport.yml&title=%5BBUG%5D) [![bug](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/bug)](https://github.com/NaverCloudPlatform/Navix/labels/bug) |
+| 기능 요청 | [기능 요청하기](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=enhancement&projects=&template=feature_request.yml&title=%5BENHANCEMENT%5D) [![enhancement](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/enhancement)](https://github.com/NaverCloudPlatform/Navix/labels/enhancement) |
+| 문의하기 | [질문 등록하기](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=question&projects=&template=question.yml&title=%5BQ%5D) [![question](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/question)](https://github.com/NaverCloudPlatform/Navix/labels/question) |
+| FAQ | [docs/](https://github.com/NaverCloudPlatform/Navix/tree/main/docs) |
+
+---
+
+## 이슈 레이블 및 상태
+
+이슈는 아래 흐름에 따라 처리됩니다:
+
+| 레이블 | 설명 |
+|---|---|
+| [![new](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/new)](https://github.com/NaverCloudPlatform/Navix/labels/new) | 최근 추가된 버그입니다. **assigned** 또는 **closed** 상태로 변경될 예정입니다. |
+| [![assigned](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/assigned)](https://github.com/NaverCloudPlatform/Navix/labels/assigned) | 엔지니어에게 할당되었습니다. |
+| [![ondev](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/ondev)](https://github.com/NaverCloudPlatform/Navix/labels/ondev) | 담당 엔지니어가 작업 중입니다. |
+| [![resolved](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/resolved)](https://github.com/NaverCloudPlatform/Navix/labels/resolved) | 버그가 수정되었습니다. |
+| [![verified](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/verified)](https://github.com/NaverCloudPlatform/Navix/labels/verified) | 버그 수정이 검증되었습니다. |
+| [![duplicate](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/duplicate)](https://github.com/NaverCloudPlatform/Navix/labels/duplicate) | 중복된 버그입니다. |
+| [![closed](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/closed)](https://github.com/NaverCloudPlatform/Navix/labels/closed) | 종료되었습니다. |

--- a/README-ko.md
+++ b/README-ko.md
@@ -1,6 +1,6 @@
 # NAVIX (Naver Linux)
 
-NAVIX는 Naver가 관리하는 Linux 배포판입니다. Naver의 인프라와 서비스에 최적화된 안정적인 엔터프라이즈급 OS 환경을 제공합니다.
+NAVIX는 OpenELA 기반의 오픈소스 Linux 배포판으로, 개발자와 시스템 관리자에게 안정적이고 안전하며 자유롭게 사용할 수 있는 Linux 플랫폼을 제공하는 것을 목표로 합니다. GPLv2 라이선스 하에 공개적으로 개발되며, 커뮤니티의 기여를 환영합니다.
 
 - [NAVIX 홈페이지](https://navix.navercorp.com/)
 - [NAVIX 저장소](https://dlnavix.navercorp.com/)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NAVIX (Naver Linux)
 
-NAVIX is a Linux distribution maintained by Naver. It provides a stable, enterprise-grade OS environment optimized for Naver's infrastructure and services.
+NAVIX is an open-source Linux distribution based on OpenELA, aiming to provide a stable, secure, and freely available Linux platform for developers and system administrators. Licensed under GPLv2, the project is openly developed and welcomes contributions from the community.
 
 - [NAVIX Homepage](https://navix.navercorp.com/)
 - [NAVIX Repository](https://dlnavix.navercorp.com/)

--- a/README.md
+++ b/README.md
@@ -7,19 +7,6 @@ NAVIX is a Linux distribution maintained by Naver. It provides a stable, enterpr
 
 ---
 
-## Getting Started
-
-### Source Code
-
-- **Source ISO:** [https://dlnavix.navercorp.com/9/x86_64/BaseOS/source/iso/](https://dlnavix.navercorp.com/9/x86_64/BaseOS/source/iso/)
-- **Per-repository source tree:**
-  ```
-  https://dlnavix.navercorp.com/9/x86_64/{repository}/source/tree/
-  ```
-  Example: `https://dlnavix.navercorp.com/9/x86_64/BaseOS/source/tree/`
-
----
-
 ## Feedback & Support
 
 | Action | Link |

--- a/README.md
+++ b/README.md
@@ -1,21 +1,87 @@
-# NAVIX(Naver Linux)
+# NAVIX (Naver Linux)
+
+NAVIX is a Linux distribution maintained by Naver. It provides a stable, enterprise-grade OS environment optimized for Naver's infrastructure and services.
 
 - [NAVIX Homepage](https://navix.navercorp.com/)
 - [NAVIX Repository](https://dlnavix.navercorp.com/)
 
-#
-- [버그 제보하기](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=bug%2Cnew&projects=&template=bugreport.yml&title=%5BBUG%5D) [![bug](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/bug)](https://github.com/NaverCloudPlatform/Navix/labels/bug)
-- [새로운 기능 제보하기](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=enhancement&projects=&template=feature_request.yml&title=%5BENHANCEMENT%5D) [![enhancement](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/enhancement)](https://github.com/NaverCloudPlatform/Navix/labels/enhancement)
-- [문의하기](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=question&projects=&template=question.yml&title=%5BQ%5D) [![question](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/question)](https://github.com/NaverCloudPlatform/Navix/labels/question)
-- [FAQ](https://github.com/NaverCloudPlatform/Navix/tree/main/docs)
+---
 
-#
-#### Status
+## Getting Started
 
-- [![new](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/new)](https://github.com/NaverCloudPlatform/Navix/labels/new) 최근 추가된 버그입니다. [![assigned](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/assigned)](https://github.com/NaverCloudPlatform/Navix/labels/assigned) 혹은 [![closed](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/closed)](https://github.com/NaverCloudPlatform/Navix/labels/closed) 상태로 변경될 예정입니다.
-- [![assigned](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/assigned)](https://github.com/NaverCloudPlatform/Navix/labels/assigned) 엔지니어에게 할당되었습니다.
-- [![ondev](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/ondev)](https://github.com/NaverCloudPlatform/Navix/labels/ondev) 담당 엔지니어가 작업 중입니다.
-- [![resolved](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/resolved)](https://github.com/NaverCloudPlatform/Navix/labels/resolved) 버그가 수정되었습니다.
-- [![verified](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/verified)](https://github.com/NaverCloudPlatform/Navix/labels/verified) 버그 수정이 검증되었습니다.
-- [![duplicate](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/duplicate)](https://github.com/NaverCloudPlatform/Navix/labels/duplicate) 중복된 버그입니다.
-- [![closed](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/closed)](https://github.com/NaverCloudPlatform/Navix/labels/closed) 종료되었습니다.
+### Source Code
+
+- **Source ISO:** [https://dlnavix.navercorp.com/9/x86_64/BaseOS/source/iso/](https://dlnavix.navercorp.com/9/x86_64/BaseOS/source/iso/)
+- **Per-repository source tree:**
+  ```
+  https://dlnavix.navercorp.com/9/x86_64/{repository}/source/tree/
+  ```
+  Example: `https://dlnavix.navercorp.com/9/x86_64/BaseOS/source/tree/`
+
+---
+
+## Feedback & Support
+
+| Action | Link |
+|---|---|
+| Report a bug | [Submit Bug Report](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=bug%2Cnew&projects=&template=bugreport.yml&title=%5BBUG%5D) [![bug](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/bug)](https://github.com/NaverCloudPlatform/Navix/labels/bug) |
+| Request a feature | [Submit Feature Request](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=enhancement&projects=&template=feature_request.yml&title=%5BENHANCEMENT%5D) [![enhancement](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/enhancement)](https://github.com/NaverCloudPlatform/Navix/labels/enhancement) |
+| Ask a question | [Submit Question](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=question&projects=&template=question.yml&title=%5BQ%5D) [![question](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/question)](https://github.com/NaverCloudPlatform/Navix/labels/question) |
+| Browse FAQ | [docs/](https://github.com/NaverCloudPlatform/Navix/tree/main/docs) |
+
+---
+
+## Contributing
+
+We welcome contributions from the community — bug reports, feature requests, and questions are all valuable.
+
+### How to Contribute
+
+#### 1. Report a Bug
+
+If you find a bug, [open a bug report](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=bug%2Cnew&projects=&template=bugreport.yml&title=%5BBUG%5D) and include:
+
+- **Component** — the affected package or subsystem (e.g. `kernel`, `openssl`)
+- **Description** — a clear explanation of the problem
+- **Steps to reproduce** — the minimal steps that trigger the issue
+- **Expected vs. actual behavior**
+- **Environment** — OS version, hardware architecture (e.g. `NAVIX 9`, `x86_64`)
+- **Screenshots or logs** — if applicable
+
+#### 2. Request a Feature
+
+Have an idea that would improve NAVIX? [Open a feature request](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=enhancement&projects=&template=feature_request.yml&title=%5BENHANCEMENT%5D) and describe:
+
+- The problem your request addresses
+- Your proposed solution
+- Any alternatives you have considered
+
+#### 3. Ask a Question
+
+For general questions about NAVIX, [open a question issue](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=question&projects=&template=question.yml&title=%5BQ%5D). You can also check the [FAQ](https://github.com/NaverCloudPlatform/Navix/tree/main/docs) first to see if it has already been answered.
+
+### Issue Lifecycle
+
+After you submit an issue, it will progress through the following states:
+
+```
+new → assigned → ondev → resolved → verified → closed
+```
+
+See the [Issue Labels & Status](#issue-labels--status) section below for details on each state.
+
+---
+
+## Issue Labels & Status
+
+Issues move through the following lifecycle:
+
+| Label | Meaning |
+|---|---|
+| [![new](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/new)](https://github.com/NaverCloudPlatform/Navix/labels/new) | Newly filed bug. Will be moved to **assigned** or **closed**. |
+| [![assigned](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/assigned)](https://github.com/NaverCloudPlatform/Navix/labels/assigned) | Assigned to an engineer. |
+| [![ondev](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/ondev)](https://github.com/NaverCloudPlatform/Navix/labels/ondev) | Actively being worked on by the assigned engineer. |
+| [![resolved](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/resolved)](https://github.com/NaverCloudPlatform/Navix/labels/resolved) | Fix has been applied. |
+| [![verified](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/verified)](https://github.com/NaverCloudPlatform/Navix/labels/verified) | Fix has been verified. |
+| [![duplicate](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/duplicate)](https://github.com/NaverCloudPlatform/Navix/labels/duplicate) | Duplicate of an existing issue. |
+| [![closed](https://img.shields.io/github/labels/NaverCloudPlatform/Navix/closed)](https://github.com/NaverCloudPlatform/Navix/labels/closed) | Issue is closed. |

--- a/docs/README-ko.md
+++ b/docs/README-ko.md
@@ -4,7 +4,7 @@
 
 네. 아래 경로를 통해 소스 코드를 확인할 수 있습니다:
 
-- **Source ISO:** [https://dlnavix.navercorp.com/9/x86_64/BaseOS/source/iso/](https://dlnavix.navercorp.com/9/x86_64/BaseOS/source/iso/)
+- **Source ISO:** [https://dlnavix.navercorp.com/navix/9/x86_64/BaseOS/iso/](https://dlnavix.navercorp.com/navix/9/x86_64/BaseOS/iso/)
 - **저장소별 소스 트리:**
   ```
   https://dlnavix.navercorp.com/9/x86_64/{저장소명}/source/tree/

--- a/docs/README-ko.md
+++ b/docs/README-ko.md
@@ -1,0 +1,40 @@
+# FAQ
+
+## 소스 코드를 제공하나요?
+
+네. 아래 경로를 통해 소스 코드를 확인할 수 있습니다:
+
+- **Source ISO:** [https://dlnavix.navercorp.com/9/x86_64/BaseOS/source/iso/](https://dlnavix.navercorp.com/9/x86_64/BaseOS/source/iso/)
+- **저장소별 소스 트리:**
+  ```
+  https://dlnavix.navercorp.com/9/x86_64/{저장소명}/source/tree/
+  ```
+  예시: `https://dlnavix.navercorp.com/9/x86_64/BaseOS/source/tree/`
+
+## 어떤 저장소가 있나요?
+
+| 저장소 | 설명 |
+|---|---|
+| **AppStream** | 애플리케이션 패키지 및 추가 소프트웨어 |
+| **BaseOS** | 핵심 OS 패키지 및 ISO |
+| **CRB** | Code Ready Builder — 추가 개발 라이브러리 |
+| **HighAvailability** | 클러스터링 및 고가용성 패키지 |
+| **ResilientStorage** | 복원력 있는 스토리지 패키지 |
+| **Updates** | 보안 및 버그 수정 업데이트 |
+
+각 저장소는 아래 하위 디렉토리를 포함합니다:
+
+| 하위 디렉토리 | 내용 |
+|---|---|
+| `os/` | 바이너리 RPM 패키지 |
+| `source/` | 소스 RPM 패키지 |
+| `debug/` | 디버그 심볼 패키지 |
+| `iso/` | ISO 이미지 (BaseOS 전용) |
+
+## 버그 제보나 기능 요청은 어떻게 하나요?
+
+메인 저장소의 이슈 템플릿을 이용해 주세요:
+
+- [버그 제보하기](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=bug%2Cnew&projects=&template=bugreport.yml&title=%5BBUG%5D)
+- [기능 요청하기](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=enhancement&projects=&template=feature_request.yml&title=%5BENHANCEMENT%5D)
+- [문의하기](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=question&projects=&template=question.yml&title=%5BQ%5D)

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 Yes. Source code is available through the following channels:
 
-- **Source ISO:** [https://dlnavix.navercorp.com/9/x86_64/BaseOS/source/iso/](https://dlnavix.navercorp.com/9/x86_64/BaseOS/source/iso/)
+- **Source ISO:** [https://dlnavix.navercorp.com/navix/9/x86_64/BaseOS/iso/](https://dlnavix.navercorp.com/navix/9/x86_64/BaseOS/iso/)
 - **Per-repository source tree:**
   ```
   https://dlnavix.navercorp.com/9/x86_64/{repository}/source/tree/

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,37 +1,40 @@
-## FAQ
-- 소스 코드 제공 여부
-  - [SourceISO](https://dlnavix.navercorp.com/9/x86_64/BaseOS/source/iso/)
-  - [Repository](https://dlnavix.navercorp.com/) 
-  `ex) https://dlnavix.navercorp.com/9/x86_64/{레파지토리}/source/tree/`
+# FAQ
 
-- Repository 구조
+## Is source code available?
 
-      .
-      └── x86_64
-          ├── AppStream
-          │   ├── debug
-          │   ├── os
-          │   └── source
-          ├── BaseOS
-          │   ├── debug
-          │   ├── iso
-          │   ├── os
-          │   └── source
-          ├── CRB
-          │   ├── debug
-          │   ├── os
-          │   └── source
-          ├── HighAvailability
-          │   ├── debug
-          │   ├── os
-          │   └── source
-          ├── ResilientStorage
-          │   ├── debug
-          │   ├── os
-          │   └── source
-          └── Updates
-              ├── debug
-              ├── os
-              └── source
+Yes. Source code is available through the following channels:
 
+- **Source ISO:** [https://dlnavix.navercorp.com/9/x86_64/BaseOS/source/iso/](https://dlnavix.navercorp.com/9/x86_64/BaseOS/source/iso/)
+- **Per-repository source tree:**
+  ```
+  https://dlnavix.navercorp.com/9/x86_64/{repository}/source/tree/
+  ```
+  Example: `https://dlnavix.navercorp.com/9/x86_64/BaseOS/source/tree/`
 
+## What repositories are available?
+
+| Repository | Description |
+|---|---|
+| **AppStream** | Application packages and additional software |
+| **BaseOS** | Core OS packages and ISOs |
+| **CRB** | Code Ready Builder — additional development libraries |
+| **HighAvailability** | Clustering and high-availability packages |
+| **ResilientStorage** | Resilient storage packages |
+| **Updates** | Security and bug-fix updates |
+
+Each repository contains the following subdirectories:
+
+| Subdirectory | Contents |
+|---|---|
+| `os/` | Binary RPM packages |
+| `source/` | Source RPM packages |
+| `debug/` | Debug symbol packages |
+| `iso/` | ISO images (BaseOS only) |
+
+## Where can I report a bug or request a feature?
+
+Please use the issue templates in the main repository:
+
+- [Report a bug](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=bug%2Cnew&projects=&template=bugreport.yml&title=%5BBUG%5D)
+- [Request a feature](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=enhancement&projects=&template=feature_request.yml&title=%5BENHANCEMENT%5D)
+- [Ask a question](https://github.com/NaverCloudPlatform/Navix/issues/new?assignees=&labels=question&projects=&template=question.yml&title=%5BQ%5D)


### PR DESCRIPTION
## Summary

This PR rewrites and expands the project documentation in English and Korean.

### Changed files

| File | Change |
|---|---|
| `README.md` | Rewrote in English — updated project intro, restructured sections, converted status labels to a table, added Contributing guide |
| `README-ko.md` | **New file** — Korean version of `README.md`, same structure |
| `docs/README.md` | Rewrote in English — restructured FAQ, added repository list table, fixed Source ISO URL |
| `docs/README-ko.md` | **New file** — Korean version of `docs/README.md` |

### Details

- **Project intro** updated to reflect NAVIX as an OpenELA-based open-source distribution licensed under GPLv2
- **Contributing guide** added with step-by-step instructions for bug reports, feature requests, and questions
- **Issue lifecycle** (`new → assigned → ondev → resolved → verified → closed`) documented
- **Source ISO URL** corrected to `https://dlnavix.navercorp.com/navix/9/x86_64/BaseOS/iso/`
- EN and KO files share identical structure throughout
